### PR TITLE
Enable Smartlook 1.8.3+

### DIFF
--- a/ios/RNSmartlook.m
+++ b/ios/RNSmartlook.m
@@ -79,32 +79,41 @@ NSDictionary<SLEventTrackingMode, NSString *> *nativeEventTrackingModeToRN;
     
     NSString *key = [rnSetupOptions valueForKey:@"smartlookAPIKey"];
     
-    NSMutableDictionary *setupOptions = [NSMutableDictionary new];
-    
+    SLSetupConfiguration *configuration = [[SLSetupConfiguration alloc] initWithKey:key];
+
     id fps = [rnSetupOptions valueForKey:@"fps"];
     if ([fps isKindOfClass:[NSNumber class]]) {
-        [setupOptions setValue:fps forKey:SLSetupOptionFramerateKey];
-    }
-    id startNewSession = [rnSetupOptions valueForKey:@"startNewSession"];
-    if ([startNewSession respondsToSelector:@selector(boolValue)]) {
-        [setupOptions setValue:[NSNumber numberWithBool:[startNewSession boolValue]] forKey:SLSetupOptionStartNewSessionKey];
-    }
-    id startNewSessionAndUser = [rnSetupOptions valueForKey:@"startNewSessionAndUser"];
-    if ([startNewSessionAndUser respondsToSelector:@selector(boolValue)]) {
-        [setupOptions setValue:[NSNumber numberWithBool:[startNewSessionAndUser boolValue]] forKey:SLSetupOptionStartNewSessionAndResetUserKey];
-    }
-    
-    [setupOptions setValue:@"REACT_NATIVE" forKey:@"__sdk_framework"];
-    id reactNativeVersion  = [rnSetupOptions valueForKey:@"_reactNativeVersion"];
-    if (reactNativeVersion != nil) {
-        [setupOptions setValue:reactNativeVersion forKey:@"__sdk_framework_version"];
-    }
-    id smartlookPluginVersion  = [rnSetupOptions valueForKey:@"_smartlookPluginVersion"];
-    if (smartlookPluginVersion != nil) {
-        [setupOptions setValue:smartlookPluginVersion forKey:@"__sdk_framework_plugin_version"];
+        configuration.framerate = [(NSNumber *)fps integerValue];
     }
 
-    [Smartlook setupWithKey:key options:setupOptions];
+    id startNewSession = [rnSetupOptions valueForKey:@"startNewSession"];
+    if ([startNewSession respondsToSelector:@selector(boolValue)]) {
+        configuration.resetSession = @YES;
+    }
+
+    id startNewSessionAndUser = [rnSetupOptions valueForKey:@"startNewSessionAndUser"];
+    if ([startNewSessionAndUser respondsToSelector:@selector(boolValue)]) {
+        configuration.resetSessionAndUser = @YES;
+    }
+
+    // Framework identification and version
+    NSDictionary<NSString *, NSString *> *internalProps = [NSDictionary new];
+    [internalProps setValue:@"REACT_NATIVE" forKey:@"framework"];
+
+    id reactNativeVersion = [rnSetupOptions valueForKey:@"_reactNativeVersion"];
+    if (reactNativeVersion != nil) {
+        [internalProps setValue:reactNativeVersion forKey:@"frameworkVersion"];
+    }
+
+    id smartlookPluginVersion  = [rnSetupOptions valueForKey:@"_smartlookPluginVersion"];
+    if (smartlookPluginVersion != nil) {
+        [internalProps setValue:smartlookPluginVersion forKey:@"frameworkPluginVersion"];
+    }
+
+    [configuration setInternalProps:internalProps];
+
+    // Setup
+    [Smartlook setupWithConfiguration:configuration];
 }
 
 RCT_EXPORT_METHOD(setup:(id)options)

--- a/ios/Smartlook.h
+++ b/ios/Smartlook.h
@@ -1,493 +1,298 @@
 //
-//  Smartlook.h
-//  Smartlook iOS SDK
-//
-//  Copyright © 2020 Smartsupp.com, s.r.o. All rights reserved.
+//  Smartlook SDK, © 2021 Smartlook.com
 //
 
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import <AVFoundation/AVFoundation.h>
-#import <CoreGraphics/CoreGraphics.h>
-#import <CoreMedia/CoreMedia.h>
-#import <CoreVideo/CoreVideo.h>
-#import <QuartzCore/QuartzCore.h>
-#import <SystemConfiguration/SystemConfiguration.h>
-#import <WebKit/WebKit.h>
 
-extern NSString * const _Nonnull SMARTLOOK_VERSION;
-extern NSString * const _Nonnull SMARTLOOK_BUILD_ID;
+@class SLSetupConfiguration;
+@class SLIntegration;
 
-#define SL_COMPATIBILITY_NAME(...)
 
-NS_SWIFT_NAME(Smartlook.SensitiveData)
-/**
- Convenience protocol to "flag" classes that present sensitive data.
- */
-@protocol SLSensitiveData
-@end
+// MARK: - Enumerations
 
-NS_SWIFT_NAME(Smartlook.NotSensitiveData)
-/**
- Convenience protocol to "flag" classes that present nonsensitive data.
- */
-@protocol SLNonSensitiveData
-@end
+typedef NSString * SLNavigationType NS_TYPED_ENUM;
+static SLNavigationType const _Nonnull SLNavigationTypeEnter = @"enter";
+static SLNavigationType const _Nonnull SLNavigationTypeExit = @"exit";
 
-// Smartlook SDK. To use, call "setupWithKey:" and "startRecording" methods from "applicationDidFinishLaunching:withOptions:" in your AppDelegate class
+typedef NSString * SLRenderingMode NS_TYPED_ENUM;
+static SLRenderingMode const _Nonnull SLRenderingModeNative = @"rendering-method-native";
+static SLRenderingMode const _Nonnull SLRenderingModeWireframe = @"rendering-method-wireframe";
+static SLRenderingMode const _Nonnull SLRenderingModeNoRendering = @"no-rendering";
 
-/// Smartlook public interface
+typedef NSString * SLRenderingModeOption NS_TYPED_ENUM;
+static SLRenderingModeOption const _Nonnull SLRenderingModeOptionNone = @"rendering-method-option-none";
+static SLRenderingModeOption const _Nonnull SLRenderingModeOptionColorWireframe = @"rendering-method-option-color-wireframe";
+static SLRenderingModeOption const _Nonnull SLRenderingModeOptionBlueprintWireframe = @"rendering-method-option-blueprint-wireframe";
+static SLRenderingModeOption const _Nonnull SLRenderingModeOptionIconBlueprintWireframe = @"rendering-method-option-icon-blueprint-wireframe";
+
+typedef NSString * SLEventTrackingMode NS_TYPED_ENUM;
+static SLEventTrackingMode const _Nonnull SLEventTrackingModeFullTracking = @"event-tracking-mode-full";
+static SLEventTrackingMode const _Nonnull SLEventTrackingModeIgnoreUserInteractionEvents = @"event-tracking-mode-ignore-user-interaction";
+static SLEventTrackingMode const _Nonnull SLEventTrackingModeNoTracking = @"event-tracking-mode-no-tracking";
+static SLEventTrackingMode const _Nonnull SLEventTrackingModeIgnoreNavigationInteractionEvents = @"event-tracking-mode-ignore-navigation-interaction-events";
+static SLEventTrackingMode const _Nonnull SLEventTrackingModeIgnoreRageClickEvents = @"event-tracking-mode-ignore-rage-click-events";
+
+// MARK:  Dashboard URL change notification
+static NSNotificationName const _Nonnull SLDashboardSessionURLChangedNotification = @"dashboard-session-URL-changed-notification";
+static NSNotificationName const _Nonnull SLDashboardVisitorURLChangedNotification = @"dashboard-visitor-URL-changed-notification";
+
+
+// MARK: - Smartlook
+
 @interface Smartlook : NSObject
 
-// MARK: Setup
 
-NS_SWIFT_NAME(Smartlook.SetupOptionKey)
-typedef NSString * SLSetupOptionKey NS_TYPED_ENUM;
-extern SLSetupOptionKey const _Nonnull SLSetupOptionFramerateKey NS_SWIFT_NAME(framerate);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionEnableCrashyticsKey NS_SWIFT_NAME(enableCrashytics);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionUseAdaptiveFramerateKey NS_SWIFT_NAME(useAdaptiveFramerate);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionAnalyticsOnlyKey NS_SWIFT_NAME(analyticsOnly);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionEventTrackingModesKey NS_SWIFT_NAME(eventTrackingModes);
-//
-extern SLSetupOptionKey const _Nonnull SLSetupOptionRenderingModeKey NS_SWIFT_NAME(renderingMode);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionRenderingModeOptionsKey NS_SWIFT_NAME(renderingModeOptions);
-//
-extern SLSetupOptionKey const _Nonnull SLSetupOptionStartNewSessionKey NS_SWIFT_NAME(startNewSession);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionStartNewSessionAndResetUserKey NS_SWIFT_NAME(startNewSessionAndResetUser);
-//
-extern SLSetupOptionKey const _Nonnull SLSetupOptionRequestHeaderFiltersKey NS_SWIFT_NAME(requestHeaderFilters);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionURLPatternFiltersKey NS_SWIFT_NAME(urlPatternFilters);
-extern SLSetupOptionKey const _Nonnull SLSetupOptionURLQueryParamFiltersKey NS_SWIFT_NAME(urlQueryParamFilters);
+// MARK: - Setup
 
-NS_SWIFT_NAME(Smartlook.RenderingMode)
-typedef NSString * SLRenderingMode NS_TYPED_ENUM;
-extern SLRenderingMode const _Nonnull SLRenderingModeNative NS_SWIFT_NAME(native);
-extern SLRenderingMode const _Nonnull SLRenderingModeWireframe NS_SWIFT_NAME(wireframe);
-extern SLRenderingMode const _Nonnull SLRenderingModeNoRendering NS_SWIFT_NAME(noRendering);
++ (void)setupWithConfiguration:(nonnull SLSetupConfiguration *)configuration;
 
-NS_SWIFT_NAME(Smartlook.RenderingModeOption)
-typedef NSString * SLRenderingModeOption NS_TYPED_ENUM;
-extern SLRenderingModeOption const _Nonnull SLRenderingModeOptionNone NS_SWIFT_NAME(none);
-extern SLRenderingModeOption const _Nonnull SLRenderingModeOptionColorWireframe NS_SWIFT_NAME(colorWireframe);
-extern SLRenderingModeOption const _Nonnull SLRenderingModeOptionBlueprintWireframe NS_SWIFT_NAME(blueprintWireframe);
-extern SLRenderingModeOption const _Nonnull SLRenderingModeOptionIconBlueprintWireframe NS_SWIFT_NAME(iconBlueprintWireframe);
-
-NS_SWIFT_NAME(Smartlook.EventTrackingMode)
-typedef NSString * SLEventTrackingMode NS_TYPED_ENUM;
-extern SLEventTrackingMode const _Nonnull SLEventTrackingModeFullTracking NS_SWIFT_NAME(fullTracking);
-extern SLEventTrackingMode const _Nonnull SLEventTrackingModeIgnoreUserInteractionEvents NS_SWIFT_NAME(ignoreUserInteractionEvents);
-extern SLEventTrackingMode const _Nonnull SLEventTrackingModeIgnoreNavigationInteractionEvents NS_SWIFT_NAME(ignoreNavigationInteractionEvents);
-extern SLEventTrackingMode const _Nonnull SLEventTrackingModeIgnoreRageClickEvents NS_SWIFT_NAME(ignoreRageClickEvents);
-extern SLEventTrackingMode const _Nonnull SLEventTrackingModeNoTracking NS_SWIFT_NAME(noTracking);
-
-// Dashboard URL change notification
-extern NSNotificationName const _Nonnull SLDashboardSessionURLChangedNotification NS_SWIFT_NAME(Smartlook.dashboardSessionURLChanged);
-extern NSNotificationName const _Nonnull SLDashboardVisitorURLChangedNotification NS_SWIFT_NAME(Smartlook.dashboardVisitorURLChanged);
-
-/**
- Setup Smartlook.
- 
- Call this method once in your `applicationDidFinishLaunching:withOptions:`.
- 
- - Attention: This method initializes Smartlook SDK, but does not start recording. To start recording, call `startRecording` method.
- 
- @param key The application (project) specific SDK key, available in your Smartlook dashboard.
- */
-+(void)setupWithKey:(nonnull NSString *)key;
-SL_COMPATIBILITY_NAME("name=setup;type=func;params=smartlookAPIKey{string}")
-
-/**
-Setup and start Smartlook.
-
-Call this method once in your `applicationDidFinishLaunching:withOptions:`.
-
-This method initializes Smartlook SDK and starts it in one step.
-
-@param key The application (project) specific SDK key, available in your Smartlook dashboard.
-*/
-+(void)setupAndStartRecordingWithKey:(nonnull NSString *)key NS_SWIFT_NAME(setupAndStartRecording(key:));
-SL_COMPATIBILITY_NAME("name=setupAndStartRecording;type=func;params=smartlookAPIKey{string}")
++ (void)setupAndStartRecordingWithConfiguration:(nonnull SLSetupConfiguration *)configuration;
 
 
-/**
- Setup Smartlook.
- 
- Call this method once in your `applicationDidFinishLaunching:withOptions:`.
+// MARK: - Reset session
 
- - Attention: This method initializes Smartlook SDK, but does not start recording. To start recording, call `startRecording` method.
- 
- @param key The application (project) specific SDK key, available in your Smartlook dashboard.
- @param options (optional) Startup options.
- */
-+(void)setupWithKey:(nonnull NSString *)key options:(nullable NSDictionary<SLSetupOptionKey,id> *)options NS_SWIFT_NAME(setup(key:options:));
-SL_COMPATIBILITY_NAME("name=setup;type=func;params=smartlookAPIKey{string},setupOptions{Dictionary[SetupOption:any]}")
++ (void)resetSessionAndUser:(BOOL)resetUser;
 
-/**
-Setup and start Smartlook.
 
-Call this method once in your `applicationDidFinishLaunching:withOptions:`.
+// MARK: - Start/Stop Recording
 
-This method both initializes Smartlook SDK and starts recording.
-
-@param key The application (project) specific SDK key, available in your Smartlook dashboard.
-@param options (optional) Startup options.
-*/
-+(void)setupAndStartRecordingWithKey:(nonnull NSString *)key options:(nullable NSDictionary<SLSetupOptionKey,id> *)options NS_SWIFT_NAME(setupAndStart(key:options:));
-SL_COMPATIBILITY_NAME("name=setupAndStartRecording;type=func;params=smartlookAPIKey{string},setupOptions{Dictionary[SetupOption:any]}")
-
-// MARK: Reset session
-
-/**
-Reset Session
-
-This method resets the current session by implicitelly starting a new one. Optionally, it also resets the user.
-
-- Attention: Each session is tied to a particular user, i.e., to reset user, new session must be created as a consequence.
-
-@param resetUser Indicates, whether new session starts with new user, too.
-*/
-+ (void)resetSessionAndUser:(BOOL)resetUser NS_SWIFT_NAME(resetSession(resetUser:));
-SL_COMPATIBILITY_NAME("name=resetSession;type=func;params=resetUser{boolean}")
-
-// MARK: Start/Stop Recording
-
-/** Starts video and events recording.
- */
 + (void)startRecording;
-SL_COMPATIBILITY_NAME("name=startRecording;type=func")
 
-/** Stops video and events recording.
- */
 + (void)stopRecording;
-SL_COMPATIBILITY_NAME("name=stopRecording;type=func")
 
-/** Current video and events recording state.
- */
 + (BOOL)isRecording;
-SL_COMPATIBILITY_NAME("name=isRecording;type=func;returns=boolean")
 
 
-// MARK: Switch Rendering Mode
+// MARK: - Switch Rendering Mode
 
-/**
- Switches the rendering mode. This can be done any time, no need to stop or start recording for it. Rendering mode can be also set as a setup option. If none is explicitly provided, `native`, the most universal mode, is used.
- */
-+ (void)setRenderingModeTo:(nonnull SLRenderingMode)renderingMode NS_SWIFT_NAME(setRenderingMode(to:));
-SL_COMPATIBILITY_NAME("name=setRenderingMode;type=func;params=renderingMode{RenderingMode}")
++ (void)setRenderingModeTo:(nonnull SLRenderingMode)renderingMode;
 
-/**
- Switches the rendering mode with optional option. This can be done any time, no need to stop or start recording for it. Rendering mode can be also set as a setup option. If none is explicitly provided, `native`, the most universal mode, is used.
- */
-+ (void)setRenderingModeTo:(nonnull SLRenderingMode)renderingMode withOption:(nullable SLRenderingModeOption)renderingModeOption NS_SWIFT_NAME(setRenderingMode(to:option:));
-SL_COMPATIBILITY_NAME("name=setRenderingMode;type=func;params=renderingMode{RenderingMode},renderingModeOption{RenderingModeOption}")
++ (void)setRenderingModeTo:(nonnull SLRenderingMode)renderingMode withOption:(nullable SLRenderingModeOption)renderingModeOption;
 
-/// Returns the current rendering mode.
 + (_Nonnull SLRenderingMode)currentRenderingMode;
-SL_COMPATIBILITY_NAME("name=currentRenderingMode;type=func;returns=RenderingMode")
 
-/// Returns current rendering mode option
 + (_Nullable SLRenderingModeOption)currentRenderingModeOption;
-SL_COMPATIBILITY_NAME("name=currentRenderingModeOption;type=func;returns=RenderingModeOption")
 
-// MARK: Events Tracking Mode
 
-/**
- Switches the event tracking mode.
- 
- This can be done any time, no need to stop or start recording for it. Event tracking mode can be also set as a setup option. If none is explicitly provided, `fullTracking` is used.
- */
-+ (void)setEventTrackingModeTo:(SLEventTrackingMode _Nonnull)eventTrackingMode NS_SWIFT_NAME(setEventTrackingMode(to:));
-SL_COMPATIBILITY_NAME("name=setEventTrackingMode;type=func;params=eventTrackingMode{EventTrackingMode}")
+// MARK: - Events Tracking Mode
 
-/**
- Switches the event tracking mode.
- 
- This can be done any time, no need to stop or start recording for it. Event tracking mode can be also set as a setup option. If none is explicitly provided, `fullTracking` is used.
- */
-+ (void)setEventTrackingModesTo:(NSArray<SLEventTrackingMode> * _Nonnull)eventTrackingModes NS_SWIFT_NAME(setEventTrackingModes(to:));
-SL_COMPATIBILITY_NAME("name=setEventTrackingModes;type=func;params=eventTrackingModes{List[EventTrackingMode]}")
 
-// Returns the currently set event tracking mode.
++ (void)setEventTrackingModeTo:(SLEventTrackingMode _Nonnull)eventTrackingMode;
+
++ (void)setEventTrackingModesTo:(NSArray<SLEventTrackingMode> * _Nonnull)eventTrackingModes;
+
 + (nonnull NSArray<SLEventTrackingMode> *)currentEventTrackingModes;
-SL_COMPATIBILITY_NAME("name=currentEventTrackingModes;type=func;returns=List[EventTrackingMode]")
-
-// MARK: Custom Events
-
-/**
- Records timestamped custom event with optional properties.
- 
- @param eventName Name that identifies the event.
- @param props Optional dictionary with additional information. Non String values will be stringified.
- */
-+ (void)trackCustomEventWithName:(nonnull NSString*)eventName props:(nullable NSDictionary<NSString*, NSString*>*)props NS_SWIFT_NAME(trackCustomEvent(name:props:));
-SL_COMPATIBILITY_NAME("name=trackCustomEvent;type=func;params=eventName{string}")
-SL_COMPATIBILITY_NAME("name=trackCustomEvent;type=func;params=eventName{string},eventProperties{Dictionary[string:string]}")
-
-/**
- Start timer for custom event.
- 
- This method does not record an event. It is the subsequent `stopTimedEvent` or `cancelTimedCustomEvent` call that refers to the `id` returned by this call that does record an event.
- 
- In the resulting event, the property dictionaries of `start` and `record` are merged (the `record` values override the `start` ones if the key is the same), and a `duration` property is added to them.
- 
- @param eventName Name of the event.
- @param props Optional dictionary with additional information.  Non String values will be stringified.
- @return return opaque event identifier
- */
-+ (id _Nonnull)startTimedCustomEventWithName:(nonnull NSString*)eventName props:(nullable NSDictionary<NSString*, NSString*>*)props NS_SWIFT_NAME(startTimedCustomEvent(name:props:));
-SL_COMPATIBILITY_NAME("name=startTimedCustomEvent;type=func;params=eventName{string};returns=string")
-SL_COMPATIBILITY_NAME("name=startTimedCustomEvent;type=func;params=eventName{string},eventProperties{Dictionary[string:string]};returns=string")
 
 
-/**
- Tracks custom times event.
- 
- This method tracks a custom timed event created by a `startTimedCustomEvent` call. The event is identified by an opaque event reference returned by the respective `startTimedCustomEvent`.
+// MARK: - Custom Events
 
- In the resulting event, the property dictionaries of `start` and `record` are merged (the `record` values override the `start` ones if the key is the same), and a `duration` property is added to them.
- 
- @param eventId event identifier as returned by the corresponding `startTimedCustomEvent`
- @param props Optional dictionary with additional information.  Non String values will be stringified.
- */
-+ (void)trackTimedCustomEventWithEventId:(id _Nonnull)eventId props:(nullable NSDictionary<NSString*, NSString*>*)props NS_SWIFT_NAME(trackTimedCustomEvent(eventId:props:));
-SL_COMPATIBILITY_NAME("name=stopTimedCustomEvent;type=func;params=eventId{string},eventProperties{Dictionary[string:string]}")
++ (void)trackCustomEventWithName:(nonnull NSString*)eventName;
 
-/**
- Track canceling of a custom times event.
- 
- This method tracks cancellation of a custom timed event created by a `startTimedCustomEvent` call. The event is identified by an opaque event reference returned by the respective `startTimedCustomEvent`.
- 
- The cancellation reason can be provided in the `reason` parameter.
- 
- In the resulting event, the property dictionaries of `start` and `record` are merged (the `record` values override the `start` ones if the key is the same), and a `duration` property is added to them.
- 
- @param eventId event identifier as returned by the corresponding `startTimedCustomEvent`
- @param reason Optional string that describes the reason for the cancelation.
- @param props Optional dictionary with additional information.  Non String values will be stringified.
- */
-+ (void)trackTimedCustomEventCancelWithEventId:(id _Nonnull)eventId reason:(NSString *_Nullable)reason props:(nullable NSDictionary<NSString*, NSString*>*)props NS_SWIFT_NAME(trackTimedCustomEventCancel(eventId:reason:props:));
-SL_COMPATIBILITY_NAME("name=cancelTimedCustomEvent;type=func;params=eventId{string},reason{string}")
-SL_COMPATIBILITY_NAME("name=cancelTimedCustomEvent;type=func;params=eventId{string},reason{string},eventProperties{Dictionary[string:string]}")
++ (void)trackCustomEventWithName:(nonnull NSString*)eventName props:(nullable NSDictionary<NSString*, NSString*>*)props;
+
++ (id _Nonnull)startTimedCustomEventWithName:(nonnull NSString*)eventName props:(nullable NSDictionary<NSString*, NSString*>*)props;
+
++ (void)trackTimedCustomEventWithEventId:(id _Nonnull)eventId props:(nullable NSDictionary<NSString*, NSString*>*)props;
+
++ (void)trackTimedCustomEventCancelWithEventId:(id _Nonnull)eventId reason:(NSString *_Nullable)reason props:(nullable NSDictionary<NSString*, NSString*>*)props;
 
 
 // MARK: - Session and Global Event Properties
 
-/** Set the app's user identifier.
- @param userIdentifier The application-specific user identifier.
- */
 + (void)setUserIdentifier:(nullable NSString*)userIdentifier;
-SL_COMPATIBILITY_NAME("name=setUserIdentifier;type=func;params=identifier{string}")
 
-
-NS_SWIFT_NAME(Smartlook.PropertyOption)
-/**
- Smartlook property options
-
- - SLPropertyOptionDefaults: the default value
- - SLPropertyOptionImmutable: the property is immutable. To change it, remove it first.
- */
 typedef NS_OPTIONS(NSUInteger, SLPropertyOption) {
     SLPropertyOptionDefaults    = 0,
     SLPropertyOptionImmutable   = 1 << 0
 };
 
-/**
- Custom session properties. You will see these properties in the Dashboard at Visitor details.
++ (void)setSessionPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name;
 
- @param value the property value
- @param name the property name
- */
-+ (void)setSessionPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name NS_SWIFT_NAME(setSessionProperty(value:forName:));
++ (void)setSessionPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name withOptions:(SLPropertyOption)options;
 
-/**
- Custom session properties. You will see these properties in the Dashboard at Visitor details.
++ (void)removeSessionPropertyForName:(nonnull NSString *)name;
 
- @param value the property value
- @param name the property name
- @param options how the property is managed
- */
-+ (void)setSessionPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name withOptions:(SLPropertyOption)options NS_SWIFT_NAME(setSessionProperty(value:forName:options:));
-SL_COMPATIBILITY_NAME("name=setUserProperty;type=func;params=key{string},value{string},immutable{boolean}")
-
-/**
- Removes custom session property.
-
- @param name the property name
- */
-+ (void)removeSessionPropertyForName:(nonnull NSString *)name NS_SWIFT_NAME(removeSessionProperty(forName:));
-
-/**
- Removes all the custom session properties.
- */
 + (void)clearSessionProperties;
 
++ (void)setGlobalEventPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name;
 
-/**
- Global event properties are sent with every event.
++ (void)setGlobalEventPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name withOptions:(SLPropertyOption)options;
 
- @param value the property value
- @param name the property name
- */
-+ (void)setGlobalEventPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name NS_SWIFT_NAME(setGlobalEventProperty(value:forName:));
++ (void)removeGlobalEventPropertyForName:(nonnull NSString *)name;
 
-/**
- Global event properties are sent with every event.
-
- @param value  the property value
- @param name  the property name
- @param options  how the property is managed
- */
-+ (void)setGlobalEventPropertyValue:(nonnull NSString *)value forName:(nonnull NSString *)name withOptions:(SLPropertyOption)options NS_SWIFT_NAME(setGlobalEventProperty(value:forName:options:));
-SL_COMPATIBILITY_NAME("name=setGlobalEventProperty;type=func;params=key{string},value{string},immutable{boolean}")
-
-/**
- Removes global event property so it is no longer sent with every event.
-
- @param name the property name
- */
-+ (void)removeGlobalEventPropertyForName:(nonnull NSString *)name NS_SWIFT_NAME(removeGlobalEventProperty(forName:));
-SL_COMPATIBILITY_NAME("name=removeGlobalEventProperty;type=func;params=key{string}")
-
-/**
- Removes all global event properties so they are no longer sent with every event.
- */
 + (void)clearGlobalEventProperties;
-SL_COMPATIBILITY_NAME("name=clearGlobalEventProperties;type=func")
+
 
 // MARK: - Sensitive Views
 
-/**
- Default colour of blacklisted view overlay
++ (void)setBlacklistedItemsColor:(nonnull UIColor *)color;
 
- @param color overlay colour
- */
-+ (void)setBlacklistedItemsColor:(nonnull UIColor *)color NS_SWIFT_NAME(setBlacklistedItem(color:));
-SL_COMPATIBILITY_NAME("name=setBlacklistedItemsColor;type=func;params=color{color}")
++ (void)registerWhitelistedObject:(nonnull id)object;
 
-/**
- Use to exempt a view from being ovelayed in video recording as containting sensitive data.
- 
- By default, all instances of `UITextView`, `UITextField` and `WKWebView` are blacklisted.
 
- See online documentation for detailed blacklisting/whitelisting documentation.
- 
- @param object an instance of UIView, an UIView subclass or a Protocol reference
- */
-+ (void)registerWhitelistedObject:(nonnull id)object NS_SWIFT_NAME(registerWhitelisted(object:));
-SL_COMPATIBILITY_NAME("name=registerWhitelistedView;type=func;params=whitelistedView{View}")
++ (void)unregisterWhitelistedObject:(nonnull id)object;
 
-/**
- Use to stop whitelisting an object. Whitelisted objects are exempted from being ovelayed in video recording as containting sensitive data.
- 
- By default, all instances of `UITextView`, `UITextField` and `WKWebView` are blacklisted.
- 
- See online documentation for detailed blacklisting/whitelisting documentation.
- 
- @param object an instance of UIView, an UIView subclass or a Protocol reference
- */
-+ (void)unregisterWhitelistedObject:(nonnull id)object NS_SWIFT_NAME(unregisterWhitelisted(object:));
-SL_COMPATIBILITY_NAME("name=unregisterWhitelistedView;type=func;params=whitelistedView{View}")
-SL_COMPATIBILITY_NAME("name=unregisterWhitelistedClass;type=func;params=blacklistedClass{Class}")
++ (void)registerBlacklistedObject:(nonnull id)object;
 
-/**
- Add an object to the blacklist. Blacklisted objects are ovelayed in video recording.
- 
- By default, all instances of `UITextView`, `UITextField` and `WKWebView` are blacklisted.
- 
- See online documentation for detailed blacklisting/whitelisting documentation.
- 
- @param object an instance of UIView, an UIView subclass or a Protocol reference
- */
-+ (void)registerBlacklistedObject:(nonnull id)object NS_SWIFT_NAME(registerBlacklisted(object:));
-SL_COMPATIBILITY_NAME("name=registerBlacklistedClass;type=func;params=blacklistedClass{Class}")
-SL_COMPATIBILITY_NAME("name=registerBlacklistedView;type=func;params=blacklistedView{View}")
++ (void)unregisterBlacklistedObject:(nonnull id)object;
 
-/**
- Remove an object from the blacklist. Blacklisted objects are ovelayed in video recording.
- 
- By default, all instances of `UITextView`, `UITextField` and `WKWebView` are blacklisted.
- 
- See online documentation for detailed blacklisting/whitelisting documentation.
- 
- @param object an instance of UIView, an UIView subclass or a Protocol reference
- */
-+ (void)unregisterBlacklistedObject:(nonnull id)object NS_SWIFT_NAME(unregisterBlacklisted(object:));
-SL_COMPATIBILITY_NAME("name=unregisterBlacklistedView;type=func;params=blacklistedView{View}")
-SL_COMPATIBILITY_NAME("name=unregisterBlacklistedClass;type=func;params=blacklistedClass{Class}")
 
 // MARK: - Dashboard session URL
-/**
- URL leading to the Dashboard player for the current Smartlook session. This URL can be access by users with the access rights to the dashboard.
 
- @param withTimestamp decides the URL points to the current moment in the recording
- 
- @return current session recording Dashboard URL
- */
-+ (nullable NSURL *)getDashboardSessionURLWithCurrentTimestamp:(BOOL)withTimestamp NS_SWIFT_NAME(getDashboardSessionURL(withCurrentTimestamp:));
-SL_COMPATIBILITY_NAME("name=getDashboardSessionUrl;type=func;params=withCurrentTimestamp{boolean};returns=url")
++ (nullable NSURL *)getDashboardSessionURLWithCurrentTimestamp:(BOOL)withTimestamp;
 
-/**
- URL leading to the Dashboard landing page of the current visitor. This URL can be access by users with the access rights to the dashboard.
-
- @return the current visitor Dashboard URL
- */
 + (nullable NSURL *)getDashboardVisitorURL;
-SL_COMPATIBILITY_NAME("name=getDashboardVisitorUrl;type=func;returns=url")
 
-// MARK: - Custom navigation events
-
- NS_SWIFT_NAME(Smartlook.NavigationEventType)
- typedef NSString * SLNavigationType NS_TYPED_ENUM;
- extern SLNavigationType const _Nonnull SLNavigationTypeEnter NS_SWIFT_NAME(enter);
- extern SLNavigationType const _Nonnull SLNavigationTypeExit NS_SWIFT_NAME(exit);
- 
- + (void)trackNavigationEventWithControllerId:(nonnull NSString *)controllerId type:(nonnull SLNavigationType)type NS_SWIFT_NAME(trackNavigationEvent(withControllerId:type:));
-SL_COMPATIBILITY_NAME("name=trackNavigationEvent;type=func;params=name{string},viewState{ViewState}")
-
-/**
- D E P R E C A T E D
- */
-
-// MARK: - Full Sensitive Mode
-
-/**
- Use this method to enter the **full sensitive mode**. No video is recorded, just events.
- */
-+ (void)beginFullscreenSensitiveMode DEPRECATED_MSG_ATTRIBUTE("use a suitable combination of rendering and event tracking mode instead.");
-SL_COMPATIBILITY_NAME("name=startFullscreenSensitiveMode;type=func;deprecated=yes")
-
-/**
- Use this method to leave the **full sensitive mode**. Video is recorded again.
- */
-+ (void)endFullscreenSensitiveMode DEPRECATED_MSG_ATTRIBUTE("use a suitable combination of rendering and event tracking mode instead.");
-SL_COMPATIBILITY_NAME("name=stopFullscreenSensitiveMode;type=func;deprecated=yes")
-
-/**
- To check Smartlook full sensitive mode status. In full sensitive mode, no video is recorded, just events.
-
- @return fullscreen sensitive mode state
- */
-+ (BOOL)isFullscreenSensitiveModeActive DEPRECATED_MSG_ATTRIBUTE("use a suitable combination of rendering and event tracking mode instead.");
-SL_COMPATIBILITY_NAME("name=isFullscreenSensitiveModeActive;type=func;returns=boolean;deprecated=yes")
++ (void)trackNavigationEventWithControllerId:(nonnull NSString *)controllerId type:(nonnull SLNavigationType)type;
 
 
-// MARK: - Other stuff
+// MARK: - Automated Integrations
 
-+ (nullable NSURL *)getDashboardSessionURL DEPRECATED_MSG_ATTRIBUTE("use `getDashboardSessionURLWithCurrentTimestamp` instead.");
-SL_COMPATIBILITY_NAME("name=getDashboardSessionUrl;type=func;returns=url;deprecated=yes")
++ (void)enableIntegrations:(NSArray<SLIntegration *> * _Nonnull)integrations;
+
++ (void)disableIntegrations:(NSArray<SLIntegration *> * _Nonnull)integrations;
+
++ (void)disableAllIntegrations;
+
++ (NSArray<SLIntegration *> *  _Nonnull)currentlyEnabledIntegrations;
 
 @end
 
-/** Defines inspectable properties on UIView
- */
+
+// MARK: - Setup Configuration
+
+@interface SLSetupConfiguration : NSObject
+
+@property (nonatomic, strong) NSString * _Nonnull apiKey;
+
+@property (nonatomic) NSInteger framerate;
+
+@property (nonatomic) BOOL enableAdaptiveFramerate;
+
+@property (nonatomic, copy) NSArray<SLEventTrackingMode> * _Nullable eventTrackingModes;
+
+@property (nonatomic, strong) SLRenderingMode _Nullable renderingMode;
+
+@property (nonatomic, strong) SLRenderingModeOption _Nullable renderingModeOption;
+
+@property (nonatomic) BOOL resetSession;
+
+@property (nonatomic) BOOL resetSessionAndUser;
+
+@property (nonatomic, strong) NSArray * _Nullable requestHeaderFilters;
+
+@property (nonatomic, strong) NSDictionary * _Nullable urlPatternFilters;
+
+@property (nonatomic, strong) NSArray * _Nullable URLQueryParamFilters;
+
+@property (nonatomic, copy) NSArray<SLIntegration *> * _Nullable enableIntegrations;
+
+- (instancetype _Nonnull)initWithKey:(NSString *_Nonnull)apiKey;
+
+- (void)setInternalProps:(id _Nonnull)internalProps;
+
+@end;
+
+
+// MARK: - Sensitivity Protocols
+
+@protocol SLSensitiveData
+@end
+
+@protocol SLNonSensitiveData
+@end
+
+
+// MARK: - UIView category
+
 @interface UIView (Smartlook)
 
-/** Flags UIView instance as sensitive. For UIViews that are `UITextView`, `UITextField` and `WKWebView`, the default value is `YES`. Otherwise, the default value is `NO`.
- */
 @property (nonatomic, assign) IBInspectable BOOL slSensitive;
 
-/** Setting colour of sensitive view overlay. Views flagged as sensitive are replaced by solid color rectangles of this color. Alpha channel of the color is ignored. The default value is `black`.
- */
-@property (nonatomic, strong) IBInspectable UIColor *slOverlay;
+@end
+
+
+// MARK: - Integrations
+
+@interface SLIntegration : NSObject;
+
+@property (nonatomic, nonnull, readonly) id integratedObject;
+@property (nonatomic, nonnull, readonly) NSString *name;
+
+@property (nonatomic, readonly) BOOL isValid;
+
+@end
+
+
+// MARK: - Firebase Crashlytics
+
+static NSString * const _Nonnull SLIntegrationFirebaseCrashlyticsName = @"firebase_crashlytics";
+
+@class FIRCrashlytics;
+
+@interface SLFirebaseCrashlyticsIntegration : SLIntegration
+- (instancetype _Nonnull)initIntegrationWith:(FIRCrashlytics *_Nonnull)crashlytics;
+@end;
+
+
+// MARK: - Firebase Analytics
+
+static NSString * const _Nonnull SLIntegrationFirebaseAnalyticsName = @"firebase_analytics";
+
+@interface SLFirebaseAnalyticsIntegration : SLIntegration
+- (instancetype _Nonnull)initIntegrationWith:(Class _Nonnull)analyticsClass;
+@end
+
+
+// MARK: - Amplitude
+
+extern NSString * const _Nonnull SLIntegrationAplitudeName;
+
+@class Amplitude;
+
+@interface SLAmplitudeIntegration : SLIntegration
+- (instancetype _Nonnull)initIntegrationWith:(Amplitude *_Nonnull)amplitudeInstance;
+@end
+
+
+// MARK: - Mixpanel
+
+extern NSString * const _Nonnull SLIntegrationMixpanelName;
+
+@class Mixpanel;
+
+@interface SLMixpanelIntegration : SLIntegration
+- (instancetype _Nonnull)initIntegrationWith:(Mixpanel *_Nonnull)mixpanelInstance;
+@end
+
+
+// MARK: - Heap
+
+extern NSString * const _Nonnull SLIntegrationHeapName;
+
+@interface SLHeapIntegration : SLIntegration
+- (instancetype _Nonnull)initIntegrationWith:(Class _Nonnull)heapClass;
+@end
+
+
+// MARK: - Segment
+
+@class SEGBlockMiddleware;
+
+
+typedef NS_OPTIONS(NSUInteger, SLSegmentMiddlewareOption) {
+    SLSegmentMiddlewareOptionTrack = 1 << 0,
+    SLSegmentMiddlewareOptionScreen = 1 << 1,
+    SLSegmentMiddlewareOptionIdentify = 1 << 2,
+    SLSegmentMiddlewareOptionAlias = 1 << 3,
+    SLSegmentMiddlewareOptionReset = 1 << 4,
+    SLSegmentMiddlewareOptionAll = 0xFF,
+    SLSegmentMiddlewareOptionDefault = SLSegmentMiddlewareOptionAll & ~SLSegmentMiddlewareOptionScreen & ~SLSegmentMiddlewareOptionAlias,
+};
+
+@interface Smartlook (Segment)
+
++(SEGBlockMiddleware * _Nullable)segmentSourceMiddlewareWithOptions:(SLSegmentMiddlewareOption)option whereSEGResetEventTypeIs:(NSInteger)resetEventType;
 
 @end

--- a/smartlook-react-native-bridge.podspec
+++ b/smartlook-react-native-bridge.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'React'
-  s.dependency 'Smartlook', '~> 1.7.10'
+  s.dependency 'Smartlook', '~> 1.8.3'
 
 end


### PR DESCRIPTION
The changes:
- change the `podspec` configuration to force latest iOS SDK
- replace the `Smartlook.h` header file with the current native iOS SDK header
- replace the deprecated native Smartlook setup methods used in our bridge with the current ones